### PR TITLE
Replace wc with tail + bash arrays

### DIFF
--- a/pomodoro.sh
+++ b/pomodoro.sh
@@ -240,7 +240,8 @@ main () {
     # infinite loop
     START=1
     if [ -f "$LOG_FILENAME" ]; then
-        START=$(wc -l < "$LOG_FILENAME")
+        arr=($(tail -1 $LOG_FILENAME))
+        START=${arr[1]}
         START=$((START+1))
     fi
     while true; do

--- a/pomodoro.sh
+++ b/pomodoro.sh
@@ -240,8 +240,8 @@ main () {
     # infinite loop
     START=1
     if [ -f "$LOG_FILENAME" ]; then
-        arr=($(tail -1 $LOG_FILENAME))
-        START=${arr[1]}
+        arr=($(tail -1 $LOG_FILENAME)) # create an array of words from the last line
+        START=${arr[1]} # second item is the latest pomodoro
         START=$((START+1))
     fi
     while true; do


### PR DESCRIPTION
Closes #23

Replaces `wc` with `tail` which is more widely used I think.